### PR TITLE
fix(zeromount): guard against ERR_PTR filename in stat hook

### DIFF
--- a/android12-5.10/KernelSU-Next/patches/60_zeromount-android12-5.10.patch
+++ b/android12-5.10/KernelSU-Next/patches/60_zeromount-android12-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android12-5.10/ReSukiSU/patches/60_zeromount-android12-5.10.patch
+++ b/android12-5.10/ReSukiSU/patches/60_zeromount-android12-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android12-5.10/SukiSU-Ultra/patches/60_zeromount-android12-5.10.patch
+++ b/android12-5.10/SukiSU-Ultra/patches/60_zeromount-android12-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android12-5.10/WildKSU/patches/60_zeromount-android12-5.10.patch
+++ b/android12-5.10/WildKSU/patches/60_zeromount-android12-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android12-5.4/ReSukiSU/patches/60_zeromount-android12-5.4.patch
+++ b/android12-5.4/ReSukiSU/patches/60_zeromount-android12-5.4.patch
@@ -378,7 +378,7 @@ diff '--color=auto' -ruN a/fs/stat.c work/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android12-5.4/SukiSU-Ultra/patches/60_zeromount-android12-5.4.patch
+++ b/android12-5.4/SukiSU-Ultra/patches/60_zeromount-android12-5.4.patch
@@ -378,7 +378,7 @@ diff '--color=auto' -ruN a/fs/stat.c work/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.10/KernelSU-Next/patches/60_zeromount-android13-5.10.patch
+++ b/android13-5.10/KernelSU-Next/patches/60_zeromount-android13-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.10/ReSukiSU/patches/60_zeromount-android13-5.10.patch
+++ b/android13-5.10/ReSukiSU/patches/60_zeromount-android13-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.10/SukiSU-Ultra/patches/60_zeromount-android13-5.10.patch
+++ b/android13-5.10/SukiSU-Ultra/patches/60_zeromount-android13-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.10/WildKSU/patches/60_zeromount-android13-5.10.patch
+++ b/android13-5.10/WildKSU/patches/60_zeromount-android13-5.10.patch
@@ -380,7 +380,7 @@ index 9c699e632..c4a5678b8 100644
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.15/KernelSU-Next/patches/60_zeromount-android13-5.15.patch
+++ b/android13-5.15/KernelSU-Next/patches/60_zeromount-android13-5.15.patch
@@ -371,7 +371,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.15/ReSukiSU/patches/60_zeromount-android13-5.15.patch
+++ b/android13-5.15/ReSukiSU/patches/60_zeromount-android13-5.15.patch
@@ -371,7 +371,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.15/SukiSU-Ultra/patches/60_zeromount-android13-5.15.patch
+++ b/android13-5.15/SukiSU-Ultra/patches/60_zeromount-android13-5.15.patch
@@ -371,7 +371,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android13-5.15/WildKSU/patches/60_zeromount-android13-5.15.patch
+++ b/android13-5.15/WildKSU/patches/60_zeromount-android13-5.15.patch
@@ -371,7 +371,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename, 
 +                                      struct kstat *stat, unsigned int request_mask, 
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android14-5.15/KernelSU-Next/patches/60_zeromount-android14-5.15.patch
+++ b/android14-5.15/KernelSU-Next/patches/60_zeromount-android14-5.15.patch
@@ -1770,7 +1770,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android14-5.15/ReSukiSU/patches/60_zeromount-android14-5.15.patch
+++ b/android14-5.15/ReSukiSU/patches/60_zeromount-android14-5.15.patch
@@ -1770,7 +1770,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android14-5.15/SukiSU-Ultra/patches/60_zeromount-android14-5.15.patch
+++ b/android14-5.15/SukiSU-Ultra/patches/60_zeromount-android14-5.15.patch
@@ -1770,7 +1770,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android14-5.15/WildKSU/patches/60_zeromount-android14-5.15.patch
+++ b/android14-5.15/WildKSU/patches/60_zeromount-android14-5.15.patch
@@ -1770,7 +1770,7 @@ diff -ruN a/fs/stat.c b/fs/stat.c
 +static inline int zeromount_stat_hook(int dfd, const char __user *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename) {
 +        char kname[NAME_MAX + 1];
 +        long copied = strncpy_from_user(kname, filename, sizeof(kname));

--- a/android14-6.1/KernelSU-Next/patches/60_zeromount-android14-6.1.patch
+++ b/android14-6.1/KernelSU-Next/patches/60_zeromount-android14-6.1.patch
@@ -367,7 +367,7 @@
 +static inline int zeromount_stat_hook(int dfd, struct filename *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename && filename->name) {
 +        const char *kname = filename->name;
 +        if (kname[0] != '/') {

--- a/android14-6.1/ReSukiSU/patches/60_zeromount-android14-6.1.patch
+++ b/android14-6.1/ReSukiSU/patches/60_zeromount-android14-6.1.patch
@@ -367,7 +367,7 @@
 +static inline int zeromount_stat_hook(int dfd, struct filename *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename && filename->name) {
 +        const char *kname = filename->name;
 +        if (kname[0] != '/') {

--- a/android14-6.1/SukiSU-Ultra/patches/60_zeromount-android14-6.1.patch
+++ b/android14-6.1/SukiSU-Ultra/patches/60_zeromount-android14-6.1.patch
@@ -367,7 +367,7 @@
 +static inline int zeromount_stat_hook(int dfd, struct filename *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename && filename->name) {
 +        const char *kname = filename->name;
 +        if (kname[0] != '/') {

--- a/android14-6.1/WildKSU/patches/60_zeromount-android14-6.1.patch
+++ b/android14-6.1/WildKSU/patches/60_zeromount-android14-6.1.patch
@@ -367,7 +367,7 @@
 +static inline int zeromount_stat_hook(int dfd, struct filename *filename,
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (filename && filename->name) {
 +        const char *kname = filename->name;
 +        if (kname[0] != '/') {

--- a/android15-6.6/KernelSU-Next/patches/60_zeromount-android15-6.6.patch
+++ b/android15-6.6/KernelSU-Next/patches/60_zeromount-android15-6.6.patch
@@ -296,7 +296,7 @@
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android15-6.6/ReSukiSU/patches/60_zeromount-android15-6.6.patch
+++ b/android15-6.6/ReSukiSU/patches/60_zeromount-android15-6.6.patch
@@ -296,7 +296,7 @@
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android15-6.6/SukiSU-Ultra/patches/60_zeromount-android15-6.6.patch
+++ b/android15-6.6/SukiSU-Ultra/patches/60_zeromount-android15-6.6.patch
@@ -296,7 +296,7 @@
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android15-6.6/WildKSU/patches/60_zeromount-android15-6.6.patch
+++ b/android15-6.6/WildKSU/patches/60_zeromount-android15-6.6.patch
@@ -296,7 +296,7 @@
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android16-6.12/KernelSU-Next/patches/60_zeromount-android16-6.12.patch
+++ b/android16-6.12/KernelSU-Next/patches/60_zeromount-android16-6.12.patch
@@ -368,7 +368,7 @@ diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/stat.c work/fs/stat.c
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android16-6.12/ReSukiSU/patches/60_zeromount-android16-6.12.patch
+++ b/android16-6.12/ReSukiSU/patches/60_zeromount-android16-6.12.patch
@@ -368,7 +368,7 @@ diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/stat.c work/fs/stat.c
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android16-6.12/SukiSU-Ultra/patches/60_zeromount-android16-6.12.patch
+++ b/android16-6.12/SukiSU-Ultra/patches/60_zeromount-android16-6.12.patch
@@ -368,7 +368,7 @@ diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/stat.c work/fs/stat.c
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {

--- a/android16-6.12/WildKSU/patches/60_zeromount-android16-6.12.patch
+++ b/android16-6.12/WildKSU/patches/60_zeromount-android16-6.12.patch
@@ -368,7 +368,7 @@ diff '--color=auto' -ruN '--exclude=.git' work-50-base/fs/stat.c work/fs/stat.c
 +                                      struct kstat *stat, unsigned int request_mask,
 +                                      int flags) {
 +    const char *kname;
-+    if (zm_is_recursive()) return -ENOENT;
++    if (zm_is_recursive() || IS_ERR_OR_NULL(filename)) return -ENOENT;
 +    if (!filename || IS_ERR(filename)) return -ENOENT;
 +    kname = filename->name;
 +    if (kname && kname[0] != '/') {


### PR DESCRIPTION
## Bug

`zeromount_stat_hook` in `fs/stat.c` dereferences `filename->name` without checking `IS_ERR(filename)`. `vfs_statx` can receive `ERR_PTR(-ENOENT)` from `getname_flags`, which passes the existing `if (filename && filename->name)` null check since `ERR_PTR(-2)` is `0xfffffffffffffffe` (not NULL), then faults on the `->name` dereference.

This causes a kernel oops ~24s into boot, resulting in a bootloop.

### Crash signature (from pstore)

```
Unable to handle kernel paging request at virtual address fffffffffffffffe
Internal error: Oops: 0000000096000005 [#1] PREEMPT SMP
pc : vfs_statx+0x6c/0x3ec
x1 : fffffffffffffffe
x8 : fffffffffffffffe
```

## Fix

Add `IS_ERR_OR_NULL(filename)` guard before dereferencing. One-line change across all 30 patches (all kernel versions, all KSU variants).

## Tested

Built and booted android14-6.1.166-lts with ReSukiSU + SUSFS + ZeroMount. Without this fix: instant bootloop. With fix: boots successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced safety validation for file attribute operations across multiple Android kernel versions (12-16).
  * Improved handling of invalid input in file metadata resolution to prevent potential system instability.
  * Applied defensive checks across KernelSU-Next, ReSukiSU, SukiSU-Ultra, and WildKSU for greater robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->