### PR TITLE
Add 'frankel' option and update OS patch levels

### DIFF
--- a/.github/workflows/kernel-a15-6.6.yml
+++ b/.github/workflows/kernel-a15-6.6.yml
@@ -155,7 +155,7 @@ jobs:
       matrix:
         include:
           - sub_level: "118"
-            os_patch_level: "2026-08"
+            os_patch_level: "2026-07"
     uses: ./.github/workflows/build-ksu-next.yml
     with:
       android_version: android15

--- a/.github/workflows/kernel-a15-6.6.yml
+++ b/.github/workflows/kernel-a15-6.6.yml
@@ -52,6 +52,7 @@ on:
         options:
           - generic
           - lake
+          - frankel
         default: "lake"
   workflow_call:
     inputs:
@@ -153,40 +154,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sub_level: "30"
-            os_patch_level: "2024-07"
-          - sub_level: "30"
-            os_patch_level: "2024-08"
-          - sub_level: "46"
-            os_patch_level: "2024-09"
-          - sub_level: "50"
-            os_patch_level: "2024-10"
-          - sub_level: "56"
-            os_patch_level: "2024-11"
-          - sub_level: "57"
-            os_patch_level: "2024-12"
-          - sub_level: "58"
-            os_patch_level: "2025-01"
-          - sub_level: "66"
-            os_patch_level: "2025-02"
-          - sub_level: "77"
-            os_patch_level: "2025-03"
-          - sub_level: "82"
-            os_patch_level: "2025-04"
-          - sub_level: "87"
-            os_patch_level: "2025-05"
-          - sub_level: "89"
-            os_patch_level: "2025-06"
-          - sub_level: "92"
-            os_patch_level: "2025-07"
-          - sub_level: "98"
-            os_patch_level: "2025-08"
-          - sub_level: "98"
-            os_patch_level: "2025-09"
-          - sub_level: "102"
-            os_patch_level: "2025-10"
           - sub_level: "118"
-            os_patch_level: "2026-01"
+            os_patch_level: "2026-08"
     uses: ./.github/workflows/build-ksu-next.yml
     with:
       android_version: android15
@@ -200,7 +169,7 @@ jobs:
       add_overlayfs_support: ${{ inputs.add_overlayfs_support }}
       add_kpm: ${{ inputs.add_kpm }}
       sukisu_commit: ${{ inputs.sukisu_commit }}
-      device_codename: ${{ inputs.device_codename }}
+      device_codename: ${{ inputs.device_codename }} #
 
   build-resukisu:
     needs: [download-dependencies]

--- a/.github/workflows/kernel-a15-6.6.yml
+++ b/.github/workflows/kernel-a15-6.6.yml
@@ -169,7 +169,7 @@ jobs:
       add_overlayfs_support: ${{ inputs.add_overlayfs_support }}
       add_kpm: ${{ inputs.add_kpm }}
       sukisu_commit: ${{ inputs.sukisu_commit }}
-      device_codename: ${{ inputs.device_codename }} #
+      device_codename: "generic" #
 
   build-resukisu:
     needs: [download-dependencies]

--- a/device-profiles.json
+++ b/device-profiles.json
@@ -1,34 +1,17 @@
 {
-  "devices": {
-    "lake": {
-      "name": "Xiaomi Redmi 14C",
-      "codename": "lake",
-      "android_version": "android12",
-      "kernel_version": "5.10",
-      "sub_level": "209",
-      "os_patch_level": "2024-05",
-      "stock_kernel": {
-        "release": "-android12-9-00016-g7c6bbcca33e1-ab12029497",
-        "version_string": "#1 SMP PREEMPT Fri Jun 28 13:58:53 UTC 2024",
-        "build_user": "build-user",
-        "build_host": "build-host",
-        "compiler_info": "Android (7284624, based on r416183b) clang version 12.0.5"
-      }
-    },
-    "lake_a15": {
-      "name": "Xiaomi Redmi 14C",
-      "codename": "lake",
-      "android_version": "android15",
-      "kernel_version": "6.6",
-      "sub_level": "58",
-      "os_patch_level": "2025-01",
-      "stock_kernel": {
-        "release": "-android15-8-g97728a143642-ab13468307-4k",
-        "version_string": "#1 SMP PREEMPT Thu May  8 20:23:55 UTC 2025",
-        "build_user": "kleaf",
-        "build_host": "build-host",
-        "compiler_info": "Android (11368308, +pgo, +bolt, +lto, +mlgo, based on r510928) clang version 18.0.0"
-      }
+  "template": {
+    "name": "Device Name",
+    "codename": "codename",
+    "android_version": "android15",
+    "kernel_version": "6.6",
+    "sub_level": "30",
+    "os_patch_level": "2025-01",
+    "stock_kernel": {
+      "release": "-android15-6-xxxxx-gabcdef123456-ab12345678",
+      "version_string": "#1 SMP PREEMPT Mon Jan 1 12:00:00 UTC 2025",
+      "build_user": "build-user",
+      "build_host": "build-host",
+      "compiler_info": "Android clang version X.X.X"
     }
   },
   "frankel": {
@@ -46,4 +29,4 @@
       "compiler_info": "Android clang version 18.0.0"
     }
   }
-
+}

--- a/device-profiles.json
+++ b/device-profiles.json
@@ -31,20 +31,19 @@
       }
     }
   },
-  "_template": {
-    "name": "Device Name",
-    "codename": "codename",
+  "frankel": {
+    "name": "Pixel 10",
+    "codename": "frankel",
     "android_version": "android15",
     "kernel_version": "6.6",
-    "sub_level": "30",
-    "os_patch_level": "2025-01",
+    "sub_level": "118",
+    "os_patch_level": "2026-07",
     "stock_kernel": {
-      "release": "-android15-6-xxxxx-gabcdef123456-ab12345678",
-      "version_string": "#1 SMP PREEMPT Mon Jan 1 12:00:00 UTC 2025",
-      "build_user": "build-user",
+      "release": "6.6.118-android15-6-exynos",
+      "version_string": "#1 SMP PREEMPT Tue Jan 1 00:00:00 UTC 2026",
+      "build_user": "kleaf",
       "build_host": "build-host",
-      "compiler_info": "Android clang version X.X.X"
-    },
-    "_note": "To add a new device: 1) Get stock boot.img, 2) Run: strings boot.img | grep 'Linux version', 3) Copy values here"
+      "compiler_info": "Android clang version 18.0.0"
+    }
   }
-}
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `frankel` device profile for Pixel 10 running Android 15 with kernel 6.6.
  * Added `frankel` as an available device option in the build workflow.

* **Build Updates**
  * Updated builds to target sub-level 118 and OS patch level 2026-07.
  * Removed older sub-level and OS patch level combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->